### PR TITLE
Apply KGP for shared configuration and constraint Kotlin version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ val agpGroupPrefix = "com.android.tools"
 
 dependencies {
   shared(gradleApi())
+  shared(kotlin("gradle-plugin"))
 
   // Add all AGP dependencies but the AGP itself.
   configurations.detachedConfiguration(create(stable.agp.get()))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,11 @@ configurations.configureEach {
   if (name != shared.name) {
     extendsFrom(shared.get())
   }
+  resolutionStrategy.eachDependency {
+    if (requested.group == "org.jetbrains.kotlin") {
+      useVersion(embeddedKotlinVersion)
+    }
+  }
 }
 
 val agpGroupPrefix = "com.android.tools"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
   kotlin("jvm") version embeddedKotlinVersion
 }
 
+val agpGroupPrefix = "com.android.tools"
+val kotlinGroup = "org.jetbrains.kotlin"
+
 // Match all directories that look like version numbers, e.g. 8.11.1, 8.13.0-alpha02.
 val versionDirPattern = """
   ^\d+\.\d+\.\d+(-alpha\d+)?$
@@ -28,13 +31,11 @@ configurations.configureEach {
     extendsFrom(shared.get())
   }
   resolutionStrategy.eachDependency {
-    if (requested.group == "org.jetbrains.kotlin") {
+    if (requested.group == kotlinGroup) {
       useVersion(embeddedKotlinVersion)
     }
   }
 }
-
-val agpGroupPrefix = "com.android.tools"
 
 dependencies {
   shared(gradleApi())


### PR DESCRIPTION
```diff
-+--- androidx.databinding:databinding-compiler-common:8.12.1
-|    \--- com.android.tools.build.jetifier:jetifier-core:1.0.0-beta10
-|         +--- com.google.code.gson:gson:2.8.0 -> 2.11.0
-|         |    \--- com.google.errorprone:error_prone_annotations:2.27.0 -> 2.30.0
-|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 2.1.20
-|              +--- org.jetbrains:annotations:13.0 -> 23.0.0
-|              +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 2.1.20 (c)
-|              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 2.1.20 (c)
++--- org.jetbrains.kotlin:kotlin-gradle-plugin -> 2.2.0
+|    +--- org.jetbrains.kotlin:kotlin-gradle-plugin-idea:2.2.0
+|    |    +--- org.jetbrains.kotlin:kotlin-tooling-core:2.2.0
+|    |    \--- org.jetbrains.kotlin:kotlin-gradle-plugin-annotations:2.2.0
+|    +--- org.jetbrains.kotlin:kotlin-gradle-plugin-idea-proto:2.2.0
+|    |    \--- org.jetbrains.kotlin:kotlin-gradle-plugin-idea:2.2.0 (*)
+|    +--- org.jetbrains.kotlin:kotlin-klib-commonizer-api:2.2.0
+|    |    \--- org.jetbrains.kotlin:kotlin-native-utils:2.2.0
+|    |         +--- org.jetbrains.kotlin:kotlin-util-io:2.2.0
+|    |         \--- org.jetbrains.kotlin:kotlin-util-klib:2.2.0
+|    |              \--- org.jetbrains.kotlin:kotlin-util-io:2.2.0
+|    +--- org.jetbrains.kotlin:kotlin-build-statistics:2.2.0
+|    |    +--- org.jetbrains.kotlin:kotlin-build-tools-api:2.2.0
+|    |    \--- com.google.code.gson:gson:2.11.0
+|    |         \--- com.google.errorprone:error_prone_annotations:2.27.0 -> 2.30.0
+|    +--- org.jetbrains.kotlin:kotlin-util-klib-metadata:2.2.0
+|    |    +--- org.jetbrains.kotlin:kotlin-util-io:2.2.0
+|    |    \--- org.jetbrains.kotlin:kotlin-util-klib:2.2.0 (*)
+|    +--- org.jetbrains.kotlin:abi-tools-api:2.2.0
+|    +--- org.jetbrains.kotlin:kotlin-gradle-plugins-bom:2.2.0
+|    |    +--- org.jetbrains.kotlin:kotlin-gradle-plugin-api:2.2.0 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-gradle-plugin-model:2.2.0 (c)
+|    |    +--- org.jetbrains.kotlin:fus-statistics-gradle-plugin:2.2.0 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-tooling-core:2.2.0 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-gradle-plugin-annotations:2.2.0 (c)
+|    |    \--- org.jetbrains.kotlin:kotlin-native-utils:2.2.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-gradle-plugin-api:2.2.0
+|    |    +--- org.jetbrains.kotlin:kotlin-gradle-plugins-bom:2.2.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-gradle-plugin-annotations:2.2.0
+|    |    +--- org.jetbrains.kotlin:kotlin-native-utils:2.2.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-tooling-core:2.2.0
+|    |    \--- org.jetbrains.kotlin:kotlin-build-tools-api:2.2.0
+|    +--- org.jetbrains.kotlin:kotlin-gradle-plugin-model:2.2.0
+|    |    +--- org.jetbrains.kotlin:kotlin-gradle-plugin-api:2.2.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-gradle-plugins-bom:2.2.0 (*)
+|    +--- org.jetbrains.kotlin:fus-statistics-gradle-plugin:2.2.0
+|    |    \--- org.jetbrains.kotlin:kotlin-gradle-plugin-api:2.2.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-compiler-runner:2.2.0
+|         +--- org.jetbrains.kotlin:kotlin-daemon-client:2.2.0
+|         \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0 -> 1.9.0
+|              +--- org.jetbrains:annotations:23.0.0
+|              +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.9.0
+|              |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.9.0 (c)
+|              \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.0 -> 2.1.20
+|                   +--- org.jetbrains:annotations:13.0 -> 23.0.0
+|                   +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0 -> 2.1.20 (c)
+|                   \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0 -> 2.1.20 (c)
++--- androidx.databinding:databinding-compiler-common:8.12.1
+|    \--- com.android.tools.build.jetifier:jetifier-core:1.0.0-beta10
+|         +--- com.google.code.gson:gson:2.8.0 -> 2.11.0 (*)
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 2.1.20 (*)
-\--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.9.0
-     +--- org.jetbrains:annotations:23.0.0
-     +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.9.0
-     |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.9.0 (c)
-     \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.0 -> 2.1.20 (*)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.9.0 (*)
+\--- org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0 (c)
```